### PR TITLE
Use epoxy instead of glew

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package (Wayland REQUIRED)
 find_package (WaylandScanner REQUIRED)
 find_package (PkgConfig REQUIRED)
 pkg_search_module (GLFW REQUIRED glfw3)
-pkg_search_module (GLEW REQUIRED glew)
+pkg_search_module (EPOXY REQUIRED epoxy)
 
 option (WITH_ASAN "Enable ASan" OFF)
 
@@ -30,6 +30,6 @@ include_directories (nuklear/)
 include_directories ("${CMAKE_BINARY_DIR}")
 
 add_executable (wlay main.c ${WLR_OUTPUT_MANAGEMENT_SRC})
-target_link_libraries (wlay ${GLFW_LIBRARIES} ${GLEW_LIBRARIES} ${Wayland_LIBRARIES})
+target_link_libraries (wlay ${GLFW_LIBRARIES} ${EPOXY_LIBRARIES} ${Wayland_LIBRARIES})
 
 install (TARGETS wlay RUNTIME DESTINATION bin COMPONENT bin)

--- a/main.c
+++ b/main.c
@@ -12,7 +12,9 @@
 #include <stdbool.h>
 #include <wayland-client.h>
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
+#include <epoxy/glx.h>
+
 #include <GLFW/glfw3.h>
 
 #include "wayland-wlr-output-management-client-protocol.h"
@@ -444,10 +446,6 @@ static void wlay_gui_init(struct wlay_state *wlay)
 
     /* OpenGL */
     glViewport(0, 0, WINDOW_WIDTH, WINDOW_HEIGHT);
-    glewExperimental = 1;
-    if (glewInit() != GLEW_OK) {
-        fail("GLEW failed to initialize");
-    }
 
     wlay->nk = nk_glfw3_init(wlay->gl.window, NK_GLFW3_INSTALL_CALLBACKS);
     /* Load Fonts: if none of these are loaded a default font will be used  */


### PR DESCRIPTION
Fixes issues related to glew-wayland.

Thanks to earnestly from #archlinux@freenode for poiting me to use epoxy.